### PR TITLE
Update python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8247,6 +8247,16 @@ python3-pyosmium:
   fedora: [python3-osmium]
   nixos: [python3Packages.pyosmium]
   ubuntu: [python3-pyosmium]
+python3-pyotp-pip:
+  debian:
+    pip:
+      packages: [pyotp]
+  fedora:
+    pip:
+      packages: [pyotp]
+  ubuntu:
+    pip:
+      packages: [pyotp]
 python3-pyparsing:
   arch: [python-pyparsing]
   debian: [python3-pyparsing]


### PR DESCRIPTION
added pyotp to python.yaml in  rosdep


Please add the following dependency to the rosdep database.

pyotp


## Package Upstream Source:

https://github.com/pyauth/pyotp

## Purpose of using this:

PyOTP is a Python library for generating and verifying one-time passwords.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://github.com/pyauth/pyotp
- Ubuntu: https://packages.ubuntu.com/
  - https://github.com/pyauth/pyotp
- Fedora: https://packages.fedoraproject.org/
  - https://github.com/pyauth/pyotp
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available
